### PR TITLE
Disable native AI for mirespider_lurker and mirespider_paralytic

### DIFF
--- a/code/modules/mob/living/simple_animal/rogue/creacher/mirespiders.dm
+++ b/code/modules/mob/living/simple_animal/rogue/creacher/mirespiders.dm
@@ -184,6 +184,8 @@
 	STAPER = 15
 	pixel_x = -4
 
+	AIStatus = AI_OFF
+	can_have_ai = FALSE
 	ai_controller = /datum/ai_controller/mirespider_lurker
 	projectiletype = /obj/projectile/bullet/spider
 
@@ -295,6 +297,8 @@
 	STASPD = 12
 	STAPER = 7
 
+	AIStatus = AI_OFF
+	can_have_ai = FALSE
 	ai_controller = /datum/ai_controller/mirespider_paralytic
 
 /datum/intent/simple/bite/mirespider_paralytic


### PR DESCRIPTION
### Motivation
- Prevent the native `simple_animal` AI from running on mire spider mobs that are driven by an `ai_controller`, avoiding conflicting or duplicate AI behavior.

### Description
- Add `AIStatus = AI_OFF` and `can_have_ai = FALSE` to `/mob/living/simple_animal/hostile/rogue/mirespider_lurker` and `/mob/living/simple_animal/hostile/rogue/mirespider_paralytic` in `code/modules/mob/living/simple_animal/rogue/creacher/mirespiders.dm` so they use only their assigned `ai_controller`.

### Testing
- No automated tests were run for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_696d0b71d7dc83338c1fe0047bc0b62e)