### PR TITLE
Fix runtime guards in map loading, timers, movement, and dirtclod handling

### DIFF
--- a/code/controllers/subsystem/timer.dm
+++ b/code/controllers/subsystem/timer.dm
@@ -352,7 +352,7 @@ SUBSYSTEM_DEF(timer)
 	if ((timeToRun < world.time || timeToRun < SStimer.head_offset) && !(flags & TIMER_CLIENT_TIME))
 		CRASH("Invalid timer state: Timer created that would require a backtrack to run (addtimer would never let this happen): [SStimer.get_timer_debug_string(src)]")
 
-	if (callBack.object != GLOBAL_PROC && !QDESTROYING(callBack.object))
+	if (callBack.object != GLOBAL_PROC && isdatum(callBack.object) && !QDESTROYING(callBack.object))
 		LAZYADD(callBack.object.active_timers, src)
 
 	bucketJoin()
@@ -449,11 +449,13 @@ SUBSYSTEM_DEF(timer)
 
 ///Returns a string of the type of the callback for this timer
 /datum/timedevent/proc/getcallingtype()
-	. = "ERROR"
+	if (!callBack || !callBack.object)
+		return "NO_OBJECT"
 	if (callBack.object == GLOBAL_PROC)
-		. = "GLOBAL_PROC"
-	else
-		. = "[callBack.object.type]"
+		return "GLOBAL_PROC"
+	if (isdatum(callBack.object))
+		return "[callBack.object.type]"
+	return "[callBack.object]"
 
 /**
  * Create a new timer and insert it in the queue

--- a/code/game/area/areas.dm
+++ b/code/game/area/areas.dm
@@ -513,7 +513,8 @@ GLOBAL_LIST_EMPTY(teleportlocs)
 	if(outdoors)
 		return FALSE
 	areasize = 0
-	for(var/turf/open/T in contents)
+	var/list/area_contents = contents.Copy()
+	for(var/turf/open/T in area_contents)
 		areasize++
 
 /**

--- a/code/game/objects/items/rogueitems/natural/dirtclod.dm
+++ b/code/game/objects/items/rogueitems/natural/dirtclod.dm
@@ -37,6 +37,8 @@
 		var/dirtcount = 1
 		var/list/dirts = list()
 		for(var/obj/item/natural/dirtclod/D in T)
+			if(D == src)
+				continue
 			dirtcount++
 			dirts += D
 		if(dirtcount >=5)

--- a/code/modules/mapping/reader.dm
+++ b/code/modules/mapping/reader.dm
@@ -932,6 +932,8 @@ GLOBAL_LIST_EMPTY(map_model_default)
 		//	LISTASSERTLEN(area_instance.turfs_by_zlevel, crds.z, list())
 		//	old_area.turfs_to_uncontain_by_zlevel[crds.z] += crds
 		//	area_instance.turfs_by_zlevel[crds.z] += crds
+		if(!islist(area_instance.contents))
+			area_instance.contents = list()
 		area_instance.contents.Add(crds)
 
 		if(GLOB.use_preloader)

--- a/code/modules/mob/living/living_movement.dm
+++ b/code/modules/mob/living/living_movement.dm
@@ -16,6 +16,8 @@
 		unpixel_shift()
 
 /mob/living/CanPass(atom/movable/mover, turf/target)
+	if(!mover)
+		return (!density || wallpressed || !(mobility_flags & MOBILITY_STAND))
 	if((mover.pass_flags & PASSMOB))
 		return TRUE
 	if(istype(mover, /obj/projectile))


### PR DESCRIPTION
### Motivation
- Prevent several runtime errors encountered during map loading and round start by adding defensive guards rather than changing logic. 
- Avoid infinite-loop/watchdog triggers caused by iterating a mutating `contents` list during map/template loading. 
- Harden timer callback handling so timers referencing non-datum or deleted callback targets do not cause null/deref errors. 
- Prevent double-destroy race on dirt clod aggregation and avoid null-mover reads in movement code.

### Description
- Ensure `area_instance.contents` is a list before appending in `/datum/parsed_map/proc/build_coordinate` by initializing it when missing (`code/modules/mapping/reader.dm`).
- Make `/area/proc/update_areasize` iterate a snapshot copy of `contents` to avoid mutations during traversal (`code/game/area/areas.dm`).
- Guard timer bookkeeping in `/datum/timedevent/New` to only access `callBack.object` with `isdatum()` and make `/datum/timedevent/proc/getcallingtype()` null- and non-datum-safe (`code/controllers/subsystem/timer.dm`).
- Add a null check for `mover` at the start of `/mob/living/CanPass` to avoid reading `mover.pass_flags` when `mover` is null (`code/modules/mob/living/living_movement.dm`).
- Skip `src` when collecting nearby dirt clods to form a pile to avoid qdel-ing the same instance twice (`code/game/objects/items/rogueitems/natural/dirtclod.dm`).

### Testing
- No automated tests were run for these changes.  All modifications are minimal defensive guards intended to prevent specific runtime errors observed during map/template loading and early-round initialization.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_696d0deb70508333bf2875e17063207b)