### PR TITLE
Translate Dawnwalker UI text to Russian

### DIFF
--- a/modular/dawnwalker/dawnwalker_buffs.dm
+++ b/modular/dawnwalker/dawnwalker_buffs.dm
@@ -1,8 +1,8 @@
 #define DAWNWALKER_RAGE_FILTER "dawnwalker_rage"
 
 /atom/movable/screen/alert/status_effect/buff/dawnwalker_rage
-	name = "HUNGERFIRE"
-	desc = "Hunger and sunlight drive me into a burning frenzy."
+	name = "ГОЛОДОПЛАМЯ"
+	desc = "Голод и солнце ввергают меня в пылающее безумие."
 	icon_state = "bloodrage"
 
 /datum/status_effect/buff/dawnwalker_rage

--- a/modular/dawnwalker/dawnwalker_component.dm
+++ b/modular/dawnwalker/dawnwalker_component.dm
@@ -57,8 +57,8 @@
 /datum/component/dawnwalker/proc/update_bloodpool_display(mob/living/carbon/human/H)
 	if(!H || !dawnwalker_bloodpool)
 		return
-	dawnwalker_bloodpool.name = "Vitae: [dawnwalker_vitae]"
-	dawnwalker_bloodpool.desc = "Vitae: [dawnwalker_vitae]/[max_vitae]"
+	dawnwalker_bloodpool.name = "Витэ: [dawnwalker_vitae]"
+	dawnwalker_bloodpool.desc = "Витэ: [dawnwalker_vitae]/[max_vitae]"
 	if(dawnwalker_vitae <= 0 || max_vitae <= 0)
 		dawnwalker_bloodpool.set_value(0, 1 SECONDS)
 	else
@@ -155,7 +155,7 @@
 	var/turf/T = H.loc
 	if(!T.can_see_sky())
 		if(in_sunlight)
-			to_chat(H, span_notice("The sun's gaze fades from my skin."))
+			to_chat(H, span_notice("Солнечный взгляд отступает от моей кожи."))
 		in_sunlight = FALSE
 		return
 	var/hour = FLOOR(station_time() / 36000, 1)
@@ -166,7 +166,7 @@
 		in_sunlight = FALSE
 		return
 	if(!in_sunlight)
-		to_chat(H, span_danger("Hunger boils in my veins as the sun sears me!"))
+		to_chat(H, span_danger("Голод бурлит в моих жилах, пока солнце обжигает меня!"))
 		in_sunlight = TRUE
 	H.apply_status_effect(/datum/status_effect/buff/dawnwalker_rage)
 	if(H.has_status_effect(/datum/status_effect/buff/dawnwalker_rage))
@@ -174,7 +174,7 @@
 		H.adjustFireLoss(15, 0)
 		if(prob(20))
 			H.adjustFireLoss(60, 0)
-			to_chat(H, span_userdanger("The sun rends my raging flesh apart!"))
+			to_chat(H, span_userdanger("Солнце разрывает мою разъярённую плоть!"))
 	else
 		H.fire_act(1, 2)
 	if(dawnwalker_vitae > 0)
@@ -189,7 +189,7 @@
 	H.adjustFireLoss(max(1, round(healing_on_tick * 0.5)), 0)
 	if(last_miracle_warning + 10 SECONDS < world.time)
 		last_miracle_warning = world.time
-		to_chat(H, span_warning("The miracle stings, turning my flesh to ash."))
+		to_chat(H, span_warning("Чудо жжёт, обращая мою плоть в пепел."))
 
 /datum/component/dawnwalker/proc/handle_low_vitae_frenzy(mob/living/carbon/human/H)
 	if(dawnwalker_vitae >= 50)
@@ -220,14 +220,14 @@
 		var/mob/living/carbon/human/examiner = user
 		if(istype(examiner) && examiner.mind?.has_antag_datum(/datum/antagonist/vampire))
 			examiner.add_stress(/datum/stressevent/dawnwalker_vampire_disgust)
-			examine_list += span_boldnotice("A filthy wretch.")
+			examine_list += span_boldnotice("Грязный выродок.")
 			addtimer(CALLBACK(src, PROC_REF(handle_vampire_examine_reaction), examiner, H), 1)
 
 /datum/component/dawnwalker/proc/handle_vampire_examine_reaction(mob/living/carbon/human/examiner, mob/living/carbon/human/target)
 	if(!istype(examiner) || !istype(target))
 		return
 	if(prob(95))
-		examiner.say("[target.name], you filthy wretch!!!")
+		examiner.say("[target.name], грязный выродок!!!")
 		examiner.emote("scream", forced = TRUE)
 		examiner.playsound_local(examiner, pick('sound/vo/male/gen/scream (1).ogg','sound/vo/male/gen/scream (2).ogg'), 125, TRUE)
 

--- a/modular/dawnwalker/dawnwalker_debuffs.dm
+++ b/modular/dawnwalker/dawnwalker_debuffs.dm
@@ -10,12 +10,12 @@
 		return FALSE
 	if(owner.has_status_effect(/datum/status_effect/buff/dawnwalker_rage))
 		owner.remove_status_effect(/datum/status_effect/buff/dawnwalker_rage)
-		owner.visible_message(span_warning("[owner] looks much weaker."), span_warning("Silver snuffs my fury. I look much weaker."))
+		owner.visible_message(span_warning("[owner] выглядит гораздо слабее."), span_warning("Серебро гасит мою ярость. Я выгляжу гораздо слабее."))
 	else
-		owner.visible_message(span_warning("[owner] looks much weaker."), span_warning("I look much weaker."))
+		owner.visible_message(span_warning("[owner] выглядит гораздо слабее."), span_warning("Я выгляжу гораздо слабее."))
 	return TRUE
 
 /atom/movable/screen/alert/status_effect/debuff/dawnwalker_silver
-	name = "Silvered"
-	desc = "Silver drains my strength."
+	name = "Опаляющее серебро"
+	desc = "Серебро вытягивает мою силу."
 	icon_state = "bleed2"

--- a/modular/dawnwalker/dawnwalker_human.dm
+++ b/modular/dawnwalker/dawnwalker_human.dm
@@ -5,5 +5,5 @@
 	if(mind && HAS_TRAIT(src, TRAIT_DAWNWALKER))
 		if(statpanel("Stats"))
 			var/datum/component/dawnwalker/component = GetComponent(/datum/component/dawnwalker)
-			stat("Vitae:", "[component?.dawnwalker_vitae]/[component?.max_vitae]")
+			stat("Витэ:", "[component?.dawnwalker_vitae]/[component?.max_vitae]")
 	return

--- a/modular/dawnwalker/dawnwalker_spells.dm
+++ b/modular/dawnwalker/dawnwalker_spells.dm
@@ -1,6 +1,6 @@
 /obj/effect/proc_holder/spell/self/dawnwalker_bloodheal
-	name = "Bloodheal"
-	desc = "Spend vitae to seal weak bleeding."
+	name = "Кроволечение"
+	desc = "Потратить витэ, чтобы запечатать слабое кровотечение."
 	recharge_time = 30 SECONDS
 	cooldown_min = 30 SECONDS
 	invocation_type = "whisper"
@@ -12,7 +12,7 @@
 		return FALSE
 	var/datum/component/dawnwalker/component = user?.GetComponent(/datum/component/dawnwalker)
 	if(!component || component.dawnwalker_vitae < vitae_cost)
-		to_chat(user, span_warning("I do not have enough vitae."))
+		to_chat(user, span_warning("У меня недостаточно витэ."))
 		return FALSE
 	return TRUE
 
@@ -21,7 +21,7 @@
 		return FALSE
 	var/datum/component/dawnwalker/component = user.GetComponent(/datum/component/dawnwalker)
 	if(!component || component.dawnwalker_vitae < vitae_cost)
-		to_chat(user, span_warning("I do not have enough vitae."))
+		to_chat(user, span_warning("У меня недостаточно витэ."))
 		return FALSE
 	component.adjust_vitae(user, -vitae_cost)
 	var/closed_bleeding = FALSE
@@ -40,8 +40,8 @@
 	return TRUE
 
 /obj/effect/proc_holder/spell/self/dawnwalker_deny_the_mother
-	name = "Deny the Mother"
-	desc = "Unleash a brief surge of stolen rage."
+	name = "Отрицание Матери"
+	desc = "Высвободить краткий всплеск украденной ярости."
 	recharge_time = 1 MINUTES
 	cooldown_min = 1 MINUTES
 	invocation_type = "shout"
@@ -53,7 +53,7 @@
 		return FALSE
 	var/datum/component/dawnwalker/component = user?.GetComponent(/datum/component/dawnwalker)
 	if(!component || component.dawnwalker_vitae < vitae_cost)
-		to_chat(user, span_warning("I do not have enough vitae."))
+		to_chat(user, span_warning("У меня недостаточно витэ."))
 		return FALSE
 	return TRUE
 
@@ -62,15 +62,15 @@
 		return FALSE
 	var/datum/component/dawnwalker/component = user.GetComponent(/datum/component/dawnwalker)
 	if(!component || component.dawnwalker_vitae < vitae_cost)
-		to_chat(user, span_warning("I do not have enough vitae."))
+		to_chat(user, span_warning("У меня недостаточно витэ."))
 		return FALSE
 	component.adjust_vitae(user, -vitae_cost)
 	user.apply_status_effect(/datum/status_effect/buff/dawnwalker_rage)
 	return TRUE
 
 /obj/effect/proc_holder/spell/self/dawnwalker_bloodlick
-	name = "Bloodlick"
-	desc = "Lick blood from the ground to restore vitae."
+	name = "Кроволиз"
+	desc = "Слизнуть кровь с земли, чтобы восстановить витэ."
 	recharge_time = 8 SECONDS
 	cooldown_min = 8 SECONDS
 	invocation_type = "whisper"
@@ -101,10 +101,10 @@
 				consumed = 1
 				qdel(B)
 	if(!consumed)
-		to_chat(user, span_warning("There's no blood here to lick."))
+		to_chat(user, span_warning("Здесь нет крови, чтобы слизывать."))
 		return FALSE
 	var/datum/component/dawnwalker/component = user.GetComponent(/datum/component/dawnwalker)
 	component?.adjust_vitae(user, consumed)
 	user.add_stress(/datum/stressevent/bloodlick)
-	to_chat(user, span_notice("I lick the blood from the ground."))
+	to_chat(user, span_notice("Я слизываю кровь с земли."))
 	return TRUE

--- a/modular/dawnwalker/dawnwalker_stress.dm
+++ b/modular/dawnwalker/dawnwalker_stress.dm
@@ -1,14 +1,14 @@
 /datum/stressevent/dawnwalker_disgust
 	stressadd = 3
-	desc = span_red("Their blood reeks of deathless hunger.")
+	desc = span_red("Их кровь смердит бессмертным голодом.")
 	timer = 3 MINUTES
 
 /datum/stressevent/bloodlick
 	stressadd = 2
-	desc = span_red("I stoop so low to lick blood from the ground.")
+	desc = span_red("Я опускаюсь настолько низко, чтобы лизать кровь с земли.")
 	timer = 2 MINUTES
 
 /datum/stressevent/dawnwalker_vampire_disgust
 	stressadd = 1
-	desc = span_warning("That thing's very presence offends my blood.")
+	desc = span_warning("Одно присутствие этой твари оскорбляет мою кровь.")
 	timer = 2 MINUTES

--- a/modular/dawnwalker/dawnwalker_trait.dm
+++ b/modular/dawnwalker/dawnwalker_trait.dm
@@ -1,7 +1,7 @@
 /datum/special_trait/dawnwalker
-	name = "Dawnwalker"
-	greet_text = span_warning("I walk as a dawnwalker, living yet cursed. Blood steadies me, silver weakens me, and miracles scald my flesh.")
-	req_text = "Living races only."
+	name = "Рассветный ходок"
+	greet_text = span_warning("Я иду как рассветный ходок, живой и проклятый. Кровь поддерживает меня, серебро ослабляет, а чудеса обжигают мою плоть.")
+	req_text = "Только живые расы."
 	weight = 20
 
 /datum/special_trait/dawnwalker/can_apply(mob/living/carbon/human/character)

--- a/modular/dawnwalker/dawnwalker_virtue.dm
+++ b/modular/dawnwalker/dawnwalker_virtue.dm
@@ -1,14 +1,14 @@
 /datum/virtue/utility/dawnwalker
-	name = "Dawnwalker"
-	desc = "A living dhampir, shunned and feared. Blood sustains me, silver weakens me, and miracles scald my flesh."
-	custom_text = "Living races only. Grants a small bloodpool and blood-linked survival."
+	name = "Рассветный ходок"
+	desc = "Живой дампир, которого сторонятся и боятся. Кровь поддерживает меня, серебро ослабляет, а чудеса обжигают мою плоть."
+	custom_text = "Только живые расы. Даёт небольшой запас витэ и выживание, зависящее от крови."
 	added_traits = list(TRAIT_DAWNWALKER)
 
 /datum/virtue/utility/dawnwalker/apply_to_human(mob/living/carbon/human/recipient)
 	if(!recipient?.dna?.species)
 		return
 	if(NOBLOOD in recipient.dna.species.species_traits)
-		to_chat(recipient, span_warning("My bloodless body cannot take this curse."))
+		to_chat(recipient, span_warning("Моё бескровное тело не может вынести это проклятие."))
 		return
 	recipient.AddComponent(/datum/component/dawnwalker)
 


### PR DESCRIPTION
### Motivation
- Localize all user-facing Dawnwalker text to Russian to meet the requirement that Dawnwalker messages, UI labels and feedback appear in Russian.

### Description
- Updated the Vitae HUD label and tooltip to `Витэ` in `modular/dawnwalker/dawnwalker_component.dm` and the stat panel label in `modular/dawnwalker/dawnwalker_human.dm`.
- Translated spell names, descriptions and feedback messages in `modular/dawnwalker/dawnwalker_spells.dm` (Bloodheal, Deny the Mother, Bloodlick).
- Localized the rage buff alert and silver debuff alert texts in `modular/dawnwalker/dawnwalker_buffs.dm` and `modular/dawnwalker/dawnwalker_debuffs.dm`.
- Translated trait/virtue names and descriptions and stress messages in `modular/dawnwalker/dawnwalker_trait.dm`, `modular/dawnwalker/dawnwalker_virtue.dm`, and `modular/dawnwalker/dawnwalker_stress.dm`.

### Testing
- No automated tests were run for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69776b5771f883338f54d309e5d7afda)